### PR TITLE
Using bash instead of sh in subprocess calls of GNU parallel in Linux/Unix

### DIFF
--- a/src/UQpy/RunModel.py
+++ b/src/UQpy/RunModel.py
@@ -780,7 +780,11 @@ class RunModel:
                                          str(self.model_script) + "' {1}  ::: {" + str(self.nexist) + ".." +
                                          str(self.nexist + self.nsim - 1) + "}")
 
-        subprocess.run(self.model_command_string, shell=True)
+        # Use bash instead of the default sh in Linux/Unix platforms 
+        if platform.system() in ['Linux', 'Unix']:
+            subprocess.run(self.model_command_string, shell=True, executable='/bin/bash')
+        else:
+            subprocess.run(self.model_command_string, shell=True)
 
     ####################################################################################################################
     # Helper functions


### PR DESCRIPTION
# Using bash instead of sh in subprocess calls of GNU parallel in Linux/Unix

## Description
When using GNU parallel to run third-party software in parallel (i.e. multi-processing) on Linux the default behavior of subprocess is to use /bin/sh. This clashes with the syntax used for the model_command_string as /bin/sh shell cannot correctly unpack the numerical sequence ```::: {0..n-1}``` at the end of the GNU parallel command. Therefore, it will try to change directory into a non-existing directory (for example ```cd run_{0..9}```, where here n=10). This will produce an error as the GNU parallel command will not be correctly executed and the model will not be run in parallel. By simply checking if the system platform is Linux and explicitly telling subprocess to use /bin/bash instead of /bin/sh this error is fixed.

## Motivation and Context
This change is required to run third-party models in parallel in Linux platforms. Due to the error I encountered with the current implementation of ```RunModel.py``` in my Linux system, I opened a [stackoverflow question](https://stackoverflow.com/questions/69198548/running-a-gnu-parallel-command-using-python-subprocess/69204794#69204794). Here, there general form of this question has been solved and so the solution should be applied to ```RunModel.py```.

## How Has This Been Tested?
I have tested this change by running a version of the existing sum_scalar Matlab model in Fortran. I was able to get 10 runs in serial but was unable to run those same 10 runs in parallel as I got this error:

```
/bin/sh: 1: cd: can't cd to run_{0..9}
```

By applying the proposed change, this error is fixed for Linux platforms without affecting the original code.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.