### PR TITLE
Fix a typo link to a malicious site

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,7 +115,7 @@ For assistance with the UQpy software package, please raise an issue on the Gith
 
 .. |logo| image:: logo.jpg
     :scale: 25 %
-    :target: https://gihub.com/SURGroup/UQpy
+    :target: https://github.com/SURGroup/UQpy
     
     
 


### PR DESCRIPTION
The target link of the image is set incorrectly.
Currently, the link leads to a website that seems to spam by redirection.
Since this is a security risk with a simple fix, I chose to skip the procedure.