### PR TITLE
Bugfix/scipy integrate

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     package_dir={"": "src"},
     package_data={"": ["*.pdf"]},
     install_requires=[
-        "numpy", "scipy", "matplotlib", "scikit-learn", 'fire',
+        "numpy", "scipy>=1.6.0", "matplotlib", "scikit-learn", 'fire',
         "beartype==0.9.1",
     ],
     classifiers=[

--- a/src/UQpy/sampling/mcmc/tempering_mcmc/ParallelTemperingMCMC.py
+++ b/src/UQpy/sampling/mcmc/tempering_mcmc/ParallelTemperingMCMC.py
@@ -1,5 +1,5 @@
 from scipy.special import logsumexp
-from scipy.integrate import trapz
+from scipy.integrate import trapezoid
 
 from UQpy.sampling.mcmc import MetropolisHastings
 from UQpy.sampling.mcmc.baseclass.MCMC import *
@@ -216,7 +216,7 @@ class ParallelTemperingMCMC(TemperingMCMC):
         # use quadrature to integrate between 0 and 1
         temper_param_list_for_integration = np.copy(np.array(self.tempering_parameters))
         log_pdf_averages = np.array(log_pdf_averages)
-        int_value = trapz(x=temper_param_list_for_integration, y=log_pdf_averages)
+        int_value = trapezoid(x=temper_param_list_for_integration, y=log_pdf_averages)
         if log_Z0 is None:
             samples_p0 = self.distribution_reference.rvs(nsamples=nsamples_from_p0)
             log_Z0 = np.log(1. / nsamples_from_p0) + logsumexp(


### PR DESCRIPTION
# Replace scipy.integrate `trapz` with `trapezoid`
scipy.integrate `trapz` was renamed `trapezoid` and the `trapz` alias has now been removed. This PR replaces `trapz` with `trapezoid`.

## Description
This should fix an import error when import UQpy with Scipy >= v1.14. I added v1.6 as a minimum required version for scipy since that is when `trapezoid` was implemented and using prior versions would cause an import error.

## Related Issue
#242 

## Motivation and Context
Can't import UQpy and have scipy >=v1.14 installed.

## How Has This Been Tested?
I didn't run any tests since it was a simple name switch and should be covered in [this test](https://github.com/SURGroup/UQpy/blob/f8d0b1d6ceb2b85a0f94adf93457febff58fe189/tests/unit_tests/sampling/test_tempering.py#L98).

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.